### PR TITLE
SUPEE-9652 was released on 2017-02-07

### DIFF
--- a/static/required_magento_patches.json
+++ b/static/required_magento_patches.json
@@ -1,7 +1,8 @@
 {
-  "Community": {
-    "1.5.0.1": [
+  "Enterprise": {
+    "1.13.1.0": [
       "SUPEE-1533",
+      "SUPEE-2747",
       "SUPEE-5344",
       "SUPEE-5994",
       "SUPEE-6285",
@@ -10,10 +11,44 @@
       "SUPEE-7405",
       "SUPEE-7405 v1.1",
       "SUPEE-8788",
-      "SUPEE-8788 v2"
+      "SUPEE-8788 v2",
+      "SUPEE-9652"
     ],
-    "1.9.0.1": [
+    "1.14.2.1": [
+      "SUPEE-6788",
+      "SUPEE-7405",
+      "SUPEE-7405 v1.1",
+      "SUPEE-8788",
+      "SUPEE-8788 v2",
+      "SUPEE-9652"
+    ],
+    "1.9.0.0": [
       "SUPEE-1533",
+      "SUPEE-2750",
+      "SUPEE-5388",
+      "SUPEE-5994",
+      "SUPEE-6285",
+      "SUPEE-6482",
+      "SUPEE-6788",
+      "SUPEE-7405",
+      "SUPEE-7405 v1.1",
+      "SUPEE-8788",
+      "SUPEE-8788 v2",
+      "SUPEE-9652",
+      "Zend Security Upgrade"
+    ],
+    "1.14.3.1": [
+      "SUPEE-9652"
+    ],
+    "1.8.x": [
+      "SUPEE-2751",
+      "SUPEE-5388",
+      "SUPEE-5994",
+      "SUPEE-6285",
+      "SUPEE-6482",
+      "SUPEE-6788"
+    ],
+    "1.14.0.1": [
       "SUPEE-5344",
       "SUPEE-5994",
       "SUPEE-6285",
@@ -22,14 +57,164 @@
       "SUPEE-7405",
       "SUPEE-7405 v1.1",
       "SUPEE-8788",
-      "SUPEE-8788 v2"
+      "SUPEE-8788 v2",
+      "SUPEE-9652"
     ],
-    "1.9.2.3": [
+    "1.14.1.0": [
+      "SUPEE-5344",
+      "SUPEE-5994",
+      "SUPEE-6285",
+      "SUPEE-6482",
+      "SUPEE-6788",
+      "SUPEE-7405",
       "SUPEE-7405 v1.1",
       "SUPEE-8788",
-      "SUPEE-8788 v2"
+      "SUPEE-8788 v2",
+      "SUPEE-9652"
+    ],
+    "1.14.2.0": [
+      "SUPEE-5994",
+      "SUPEE-6285",
+      "SUPEE-6482",
+      "SUPEE-6788",
+      "SUPEE-7405",
+      "SUPEE-7405 v1.1",
+      "SUPEE-8788",
+      "SUPEE-8788 v2",
+      "SUPEE-9652"
+    ],
+    "1.12.0.2": [
+      "SUPEE-1533",
+      "SUPEE-2677",
+      "SUPEE-5345",
+      "SUPEE-5994",
+      "SUPEE-6285",
+      "SUPEE-6482",
+      "SUPEE-6788",
+      "SUPEE-7405",
+      "SUPEE-7405 v1.1",
+      "SUPEE-8788",
+      "SUPEE-8788 v2",
+      "SUPEE-9652"
+    ],
+    "1.14.2.3": [
+      "SUPEE-7405 v1.1",
+      "SUPEE-8788",
+      "SUPEE-8788 v2",
+      "SUPEE-9652"
+    ],
+    "1.14.2.2": [
+      "SUPEE-7405",
+      "SUPEE-7405 v1.1",
+      "SUPEE-8788",
+      "SUPEE-8788 v2",
+      "SUPEE-9652"
+    ],
+    "1.11.0.2": [
+      "SUPEE-1533",
+      "SUPEE-2677",
+      "SUPEE-5341",
+      "SUPEE-5994",
+      "SUPEE-6285",
+      "SUPEE-6482",
+      "SUPEE-6788",
+      "SUPEE-7405",
+      "SUPEE-7405 v1.1",
+      "SUPEE-8788",
+      "SUPEE-8788 v2",
+      "SUPEE-9652",
+      "Zend Security Upgrade"
+    ],
+    "1.13.0.2": [
+      "SUPEE-1533",
+      "SUPEE-2677",
+      "SUPEE-5344",
+      "SUPEE-5994",
+      "SUPEE-6285",
+      "SUPEE-6482",
+      "SUPEE-6788",
+      "SUPEE-7405",
+      "SUPEE-7405 v1.1",
+      "SUPEE-8788",
+      "SUPEE-8788 v2",
+      "SUPEE-9652"
+    ],
+    "1.14.3.2": [],
+    "1.7.x": [
+      "SUPEE-2751",
+      "SUPEE-5388",
+      "SUPEE-5994",
+      "SUPEE-6285",
+      "SUPEE-6482",
+      "SUPEE-6788"
+    ],
+    "1.11.1.0": [
+      "SUPEE-1533",
+      "SUPEE-2677",
+      "SUPEE-5346",
+      "SUPEE-5994",
+      "SUPEE-6285",
+      "SUPEE-6482",
+      "SUPEE-6788",
+      "SUPEE-7405",
+      "SUPEE-7405 v1.1",
+      "SUPEE-8788",
+      "SUPEE-8788 v2",
+      "SUPEE-9652",
+      "Zend Security Upgrade"
+    ],
+    "1.12.0.1": [
+      "SUPEE-1533",
+      "SUPEE-2677",
+      "SUPEE-5345",
+      "SUPEE-5994",
+      "SUPEE-6285",
+      "SUPEE-6482",
+      "SUPEE-6788",
+      "SUPEE-7405",
+      "SUPEE-7405 v1.1",
+      "SUPEE-8788",
+      "SUPEE-8788 v2",
+      "SUPEE-9652",
+      "Zend Security Upgrade"
+    ],
+    "1.11.2.0": [
+      "SUPEE-1533",
+      "SUPEE-2677",
+      "SUPEE-5346",
+      "SUPEE-5994",
+      "SUPEE-6285",
+      "SUPEE-6482",
+      "SUPEE-6788",
+      "SUPEE-7405",
+      "SUPEE-7405 v1.1",
+      "SUPEE-8788",
+      "SUPEE-8788 v2",
+      "SUPEE-9652",
+      "Zend Security Upgrade"
+    ],
+    "1.10.0.1": [
+      "SUPEE-1533",
+      "SUPEE-2750",
+      "SUPEE-5388",
+      "SUPEE-5994",
+      "SUPEE-6285",
+      "SUPEE-6482",
+      "SUPEE-6788",
+      "SUPEE-7405",
+      "SUPEE-7405 v1.1",
+      "SUPEE-8788",
+      "SUPEE-8788 v2",
+      "SUPEE-9652",
+      "Zend Security Upgrade"
+    ],
+    "1.14.3.0": [
+      "SUPEE-9652"
     ],
     "1.9.1.1": [
+      "SUPEE-1533",
+      "SUPEE-2750",
+      "SUPEE-5388",
       "SUPEE-5994",
       "SUPEE-6285",
       "SUPEE-6482",
@@ -37,18 +222,112 @@
       "SUPEE-7405",
       "SUPEE-7405 v1.1",
       "SUPEE-8788",
-      "SUPEE-8788 v2"
+      "SUPEE-8788 v2",
+      "SUPEE-9652",
+      "Zend Security Upgrade"
     ],
-    "1.4.1.0": [
+    "1.10.1.0": [
       "SUPEE-1533",
+      "SUPEE-2677",
+      "SUPEE-5390",
+      "SUPEE-5994",
+      "SUPEE-6285",
+      "SUPEE-6482",
+      "SUPEE-6788",
+      "SUPEE-7405",
+      "SUPEE-7405 v1.1",
+      "SUPEE-8788",
+      "SUPEE-8788 v2",
+      "SUPEE-9652",
+      "Zend Security Upgrade"
+    ],
+    "1.14.0.0": [
       "SUPEE-5344",
       "SUPEE-5994",
       "SUPEE-6285",
       "SUPEE-6482",
       "SUPEE-6788",
       "SUPEE-7405",
-      "SUPEE-7405 v1.1"
+      "SUPEE-7405 v1.1",
+      "SUPEE-8788",
+      "SUPEE-8788 v2",
+      "SUPEE-9652"
     ],
+    "1.11.0.0": [
+      "SUPEE-1533",
+      "SUPEE-2677",
+      "SUPEE-5341",
+      "SUPEE-5994",
+      "SUPEE-6285",
+      "SUPEE-6482",
+      "SUPEE-6788",
+      "SUPEE-7405",
+      "SUPEE-7405 v1.1",
+      "SUPEE-8788",
+      "SUPEE-8788 v2",
+      "SUPEE-9652",
+      "Zend Security Upgrade"
+    ],
+    "1.6.x": [
+      "SUPEE-2717",
+      "SUPEE-5994",
+      "SUPEE-6079",
+      "SUPEE-6285",
+      "SUPEE-6482",
+      "SUPEE-6788"
+    ],
+    "1.10.1.1": [
+      "SUPEE-1533",
+      "SUPEE-2677",
+      "SUPEE-5390",
+      "SUPEE-5994",
+      "SUPEE-6285",
+      "SUPEE-6482",
+      "SUPEE-6788",
+      "SUPEE-7405",
+      "SUPEE-7405 v1.1",
+      "SUPEE-8788",
+      "SUPEE-8788 v2",
+      "SUPEE-9652",
+      "Zend Security Upgrade"
+    ],
+    "1.14.2.4": [
+      "SUPEE-8788",
+      "SUPEE-8788 v2",
+      "SUPEE-9652"
+    ],
+    "1.12.0.0": [
+      "SUPEE-1533",
+      "SUPEE-2677",
+      "SUPEE-5345",
+      "SUPEE-5994",
+      "SUPEE-6285",
+      "SUPEE-6482",
+      "SUPEE-6788",
+      "SUPEE-7405",
+      "SUPEE-7405 v1.1",
+      "SUPEE-8788",
+      "SUPEE-8788 v2",
+      "SUPEE-9652",
+      "Zend Security Upgrade"
+    ],
+    "1.10.0.2": [
+      "SUPEE-1533",
+      "SUPEE-2750",
+      "SUPEE-5388",
+      "SUPEE-5994",
+      "SUPEE-6285",
+      "SUPEE-6482",
+      "SUPEE-6788",
+      "SUPEE-7405",
+      "SUPEE-7405 v1.1",
+      "SUPEE-8788",
+      "SUPEE-8788 v2",
+      "SUPEE-9652",
+      "Zend Security Upgrade"
+    ]
+  },
+  "Community": {
     "1.6.0.0": [
       "SUPEE-1533",
       "SUPEE-5344",
@@ -59,9 +338,18 @@
       "SUPEE-7405",
       "SUPEE-7405 v1.1",
       "SUPEE-8788",
-      "SUPEE-8788 v2"
+      "SUPEE-8788 v2",
+      "SUPEE-9652"
     ],
-    "1.7.0.2": [
+    "1.9.2.1": [
+      "SUPEE-6788",
+      "SUPEE-7405",
+      "SUPEE-7405 v1.1",
+      "SUPEE-8788",
+      "SUPEE-8788 v2",
+      "SUPEE-9652"
+    ],
+    "1.7.0.0": [
       "SUPEE-1533",
       "SUPEE-5344",
       "SUPEE-5994",
@@ -71,7 +359,8 @@
       "SUPEE-7405",
       "SUPEE-7405 v1.1",
       "SUPEE-8788",
-      "SUPEE-8788 v2"
+      "SUPEE-8788 v2",
+      "SUPEE-9652"
     ],
     "1.9.0.0": [
       "SUPEE-1533",
@@ -83,9 +372,10 @@
       "SUPEE-7405",
       "SUPEE-7405 v1.1",
       "SUPEE-8788",
-      "SUPEE-8788 v2"
+      "SUPEE-8788 v2",
+      "SUPEE-9652"
     ],
-    "1.5.1.0": [
+    "1.9.0.1": [
       "SUPEE-1533",
       "SUPEE-5344",
       "SUPEE-5994",
@@ -95,25 +385,8 @@
       "SUPEE-7405",
       "SUPEE-7405 v1.1",
       "SUPEE-8788",
-      "SUPEE-8788 v2"
-    ],
-    "1.9.1.0": [
-      "SUPEE-5344",
-      "SUPEE-5994",
-      "SUPEE-6285",
-      "SUPEE-6482",
-      "SUPEE-6788",
-      "SUPEE-7405",
-      "SUPEE-7405 v1.1",
-      "SUPEE-8788",
-      "SUPEE-8788 v2"
-    ],
-    "1.9.2.1": [
-      "SUPEE-6788",
-      "SUPEE-7405",
-      "SUPEE-7405 v1.1",
-      "SUPEE-8788",
-      "SUPEE-8788 v2"
+      "SUPEE-8788 v2",
+      "SUPEE-9652"
     ],
     "1.8.0.0": [
       "SUPEE-1533",
@@ -125,25 +398,19 @@
       "SUPEE-7405",
       "SUPEE-7405 v1.1",
       "SUPEE-8788",
-      "SUPEE-8788 v2"
+      "SUPEE-8788 v2",
+      "SUPEE-9652"
     ],
-    "1.9.3.0": [],
-    "1.9.2.4": [
-      "SUPEE-8788",
-      "SUPEE-8788 v2"
-    ],
-    "1.4.2.0": [
-      "SUPEE-1533",
-      "SUPEE-5344",
-      "SUPEE-5994",
-      "SUPEE-6285",
+    "1.9.2.0": [
       "SUPEE-6482",
       "SUPEE-6788",
       "SUPEE-7405",
-      "SUPEE-7405 v1.1"
+      "SUPEE-7405 v1.1",
+      "SUPEE-8788",
+      "SUPEE-8788 v2",
+      "SUPEE-9652"
     ],
-    "1.8.1.0": [
-      "SUPEE-1533",
+    "1.9.1.0": [
       "SUPEE-5344",
       "SUPEE-5994",
       "SUPEE-6285",
@@ -152,7 +419,21 @@
       "SUPEE-7405",
       "SUPEE-7405 v1.1",
       "SUPEE-8788",
-      "SUPEE-8788 v2"
+      "SUPEE-8788 v2",
+      "SUPEE-9652"
+    ],
+    "1.9.3.1": [
+      "SUPEE-9652"
+    ],
+    "1.4.0.0": [
+      "SUPEE-1533",
+      "SUPEE-5344",
+      "SUPEE-5994",
+      "SUPEE-6285",
+      "SUPEE-6482",
+      "SUPEE-6788",
+      "SUPEE-7405",
+      "SUPEE-7405 v1.1"
     ],
     "1.6.1.0": [
       "SUPEE-1533",
@@ -164,15 +445,87 @@
       "SUPEE-7405",
       "SUPEE-7405 v1.1",
       "SUPEE-8788",
-      "SUPEE-8788 v2"
+      "SUPEE-8788 v2",
+      "SUPEE-9652"
+    ],
+    "1.5.1.0": [
+      "SUPEE-1533",
+      "SUPEE-5344",
+      "SUPEE-5994",
+      "SUPEE-6285",
+      "SUPEE-6482",
+      "SUPEE-6788",
+      "SUPEE-7405",
+      "SUPEE-7405 v1.1",
+      "SUPEE-8788",
+      "SUPEE-8788 v2",
+      "SUPEE-9652"
+    ],
+    "1.9.2.3": [
+      "SUPEE-7405 v1.1",
+      "SUPEE-8788",
+      "SUPEE-8788 v2",
+      "SUPEE-9652"
+    ],
+    "1.9.3.0": [
+      "SUPEE-9652"
+    ],
+    "1.6.2.0": [
+      "SUPEE-1533",
+      "SUPEE-5344",
+      "SUPEE-5994",
+      "SUPEE-6285",
+      "SUPEE-6482",
+      "SUPEE-6788",
+      "SUPEE-7405",
+      "SUPEE-7405 v1.1",
+      "SUPEE-8788",
+      "SUPEE-8788 v2",
+      "SUPEE-9652"
     ],
     "1.9.2.2": [
       "SUPEE-7405",
       "SUPEE-7405 v1.1",
       "SUPEE-8788",
-      "SUPEE-8788 v2"
+      "SUPEE-8788 v2",
+      "SUPEE-9652"
     ],
+    "1.9.1.1": [
+      "SUPEE-5994",
+      "SUPEE-6285",
+      "SUPEE-6482",
+      "SUPEE-6788",
+      "SUPEE-7405",
+      "SUPEE-7405 v1.1",
+      "SUPEE-8788",
+      "SUPEE-8788 v2",
+      "SUPEE-9652"
+    ],
+    "1.9.3.2": [],
     "1.4.1.1": [
+      "SUPEE-1533",
+      "SUPEE-5344",
+      "SUPEE-5994",
+      "SUPEE-6285",
+      "SUPEE-6482",
+      "SUPEE-6788",
+      "SUPEE-7405",
+      "SUPEE-7405 v1.1"
+    ],
+    "1.5.0.1": [
+      "SUPEE-1533",
+      "SUPEE-5344",
+      "SUPEE-5994",
+      "SUPEE-6285",
+      "SUPEE-6482",
+      "SUPEE-6788",
+      "SUPEE-7405",
+      "SUPEE-7405 v1.1",
+      "SUPEE-8788",
+      "SUPEE-8788 v2",
+      "SUPEE-9652"
+    ],
+    "1.4.1.0": [
       "SUPEE-1533",
       "SUPEE-5344",
       "SUPEE-5994",
@@ -192,7 +545,39 @@
       "SUPEE-7405",
       "SUPEE-7405 v1.1",
       "SUPEE-8788",
-      "SUPEE-8788 v2"
+      "SUPEE-8788 v2",
+      "SUPEE-9652"
+    ],
+    "1.7.0.2": [
+      "SUPEE-1533",
+      "SUPEE-5344",
+      "SUPEE-5994",
+      "SUPEE-6285",
+      "SUPEE-6482",
+      "SUPEE-6788",
+      "SUPEE-7405",
+      "SUPEE-7405 v1.1",
+      "SUPEE-8788",
+      "SUPEE-8788 v2",
+      "SUPEE-9652"
+    ],
+    "1.8.1.0": [
+      "SUPEE-1533",
+      "SUPEE-5344",
+      "SUPEE-5994",
+      "SUPEE-6285",
+      "SUPEE-6482",
+      "SUPEE-6788",
+      "SUPEE-7405",
+      "SUPEE-7405 v1.1",
+      "SUPEE-8788",
+      "SUPEE-8788 v2",
+      "SUPEE-9652"
+    ],
+    "1.9.2.4": [
+      "SUPEE-8788",
+      "SUPEE-8788 v2",
+      "SUPEE-9652"
     ],
     "1.4.0.1": [
       "SUPEE-1533",
@@ -204,39 +589,7 @@
       "SUPEE-7405",
       "SUPEE-7405 v1.1"
     ],
-    "1.6.2.0": [
-      "SUPEE-1533",
-      "SUPEE-5344",
-      "SUPEE-5994",
-      "SUPEE-6285",
-      "SUPEE-6482",
-      "SUPEE-6788",
-      "SUPEE-7405",
-      "SUPEE-7405 v1.1",
-      "SUPEE-8788",
-      "SUPEE-8788 v2"
-    ],
-    "1.9.2.0": [
-      "SUPEE-6482",
-      "SUPEE-6788",
-      "SUPEE-7405",
-      "SUPEE-7405 v1.1",
-      "SUPEE-8788",
-      "SUPEE-8788 v2"
-    ],
-    "1.7.0.0": [
-      "SUPEE-1533",
-      "SUPEE-5344",
-      "SUPEE-5994",
-      "SUPEE-6285",
-      "SUPEE-6482",
-      "SUPEE-6788",
-      "SUPEE-7405",
-      "SUPEE-7405 v1.1",
-      "SUPEE-8788",
-      "SUPEE-8788 v2"
-    ],
-    "1.4.0.0": [
+    "1.4.2.0": [
       "SUPEE-1533",
       "SUPEE-5344",
       "SUPEE-5994",
@@ -245,305 +598,6 @@
       "SUPEE-6788",
       "SUPEE-7405",
       "SUPEE-7405 v1.1"
-    ]
-  },
-  "Enterprise": {
-    "1.12.0.1": [
-      "SUPEE-1533",
-      "SUPEE-2677",
-      "SUPEE-5345",
-      "SUPEE-5994",
-      "SUPEE-6285",
-      "SUPEE-6482",
-      "SUPEE-6788",
-      "SUPEE-7405",
-      "SUPEE-7405 v1.1",
-      "SUPEE-8788",
-      "SUPEE-8788 v2",
-      "Zend Security Upgrade"
-    ],
-    "1.13.0.2": [
-      "SUPEE-1533",
-      "SUPEE-2677",
-      "SUPEE-5344",
-      "SUPEE-5994",
-      "SUPEE-6285",
-      "SUPEE-6482",
-      "SUPEE-6788",
-      "SUPEE-7405",
-      "SUPEE-7405 v1.1",
-      "SUPEE-8788",
-      "SUPEE-8788 v2"
-    ],
-    "1.14.1.0": [
-      "SUPEE-5344",
-      "SUPEE-5994",
-      "SUPEE-6285",
-      "SUPEE-6482",
-      "SUPEE-6788",
-      "SUPEE-7405",
-      "SUPEE-7405 v1.1",
-      "SUPEE-8788",
-      "SUPEE-8788 v2"
-    ],
-    "1.9.1.1": [
-      "SUPEE-1533",
-      "SUPEE-2750",
-      "SUPEE-5388",
-      "SUPEE-5994",
-      "SUPEE-6285",
-      "SUPEE-6482",
-      "SUPEE-6788",
-      "SUPEE-7405",
-      "SUPEE-7405 v1.1",
-      "SUPEE-8788",
-      "SUPEE-8788 v2",
-      "Zend Security Upgrade"
-    ],
-    "1.11.0.2": [
-      "SUPEE-1533",
-      "SUPEE-2677",
-      "SUPEE-5341",
-      "SUPEE-5994",
-      "SUPEE-6285",
-      "SUPEE-6482",
-      "SUPEE-6788",
-      "SUPEE-7405",
-      "SUPEE-7405 v1.1",
-      "SUPEE-8788",
-      "SUPEE-8788 v2",
-      "Zend Security Upgrade"
-    ],
-    "1.14.2.3": [
-      "SUPEE-7405 v1.1",
-      "SUPEE-8788",
-      "SUPEE-8788 v2"
-    ],
-    "1.11.1.0": [
-      "SUPEE-1533",
-      "SUPEE-2677",
-      "SUPEE-5346",
-      "SUPEE-5994",
-      "SUPEE-6285",
-      "SUPEE-6482",
-      "SUPEE-6788",
-      "SUPEE-7405",
-      "SUPEE-7405 v1.1",
-      "SUPEE-8788",
-      "SUPEE-8788 v2",
-      "Zend Security Upgrade"
-    ],
-    "1.14.2.2": [
-      "SUPEE-7405",
-      "SUPEE-7405 v1.1",
-      "SUPEE-8788",
-      "SUPEE-8788 v2"
-    ],
-    "1.9.0.0": [
-      "SUPEE-1533",
-      "SUPEE-2750",
-      "SUPEE-5388",
-      "SUPEE-5994",
-      "SUPEE-6285",
-      "SUPEE-6482",
-      "SUPEE-6788",
-      "SUPEE-7405",
-      "SUPEE-7405 v1.1",
-      "SUPEE-8788",
-      "SUPEE-8788 v2",
-      "Zend Security Upgrade"
-    ],
-    "1.11.2.0": [
-      "SUPEE-1533",
-      "SUPEE-2677",
-      "SUPEE-5346",
-      "SUPEE-5994",
-      "SUPEE-6285",
-      "SUPEE-6482",
-      "SUPEE-6788",
-      "SUPEE-7405",
-      "SUPEE-7405 v1.1",
-      "SUPEE-8788",
-      "SUPEE-8788 v2",
-      "Zend Security Upgrade"
-    ],
-    "1.14.0.1": [
-      "SUPEE-5344",
-      "SUPEE-5994",
-      "SUPEE-6285",
-      "SUPEE-6482",
-      "SUPEE-6788",
-      "SUPEE-7405",
-      "SUPEE-7405 v1.1",
-      "SUPEE-8788",
-      "SUPEE-8788 v2"
-    ],
-    "1.10.1.0": [
-      "SUPEE-1533",
-      "SUPEE-2677",
-      "SUPEE-5390",
-      "SUPEE-5994",
-      "SUPEE-6285",
-      "SUPEE-6482",
-      "SUPEE-6788",
-      "SUPEE-7405",
-      "SUPEE-7405 v1.1",
-      "SUPEE-8788",
-      "SUPEE-8788 v2",
-      "Zend Security Upgrade"
-    ],
-    "1.14.3.0": [],
-    "1.10.0.2": [
-      "SUPEE-1533",
-      "SUPEE-2750",
-      "SUPEE-5388",
-      "SUPEE-5994",
-      "SUPEE-6285",
-      "SUPEE-6482",
-      "SUPEE-6788",
-      "SUPEE-7405",
-      "SUPEE-7405 v1.1",
-      "SUPEE-8788",
-      "SUPEE-8788 v2",
-      "Zend Security Upgrade"
-    ],
-    "1.7.x": [
-      "SUPEE-2751",
-      "SUPEE-5388",
-      "SUPEE-5994",
-      "SUPEE-6285",
-      "SUPEE-6482",
-      "SUPEE-6788"
-    ],
-    "1.11.0.0": [
-      "SUPEE-1533",
-      "SUPEE-2677",
-      "SUPEE-5341",
-      "SUPEE-5994",
-      "SUPEE-6285",
-      "SUPEE-6482",
-      "SUPEE-6788",
-      "SUPEE-7405",
-      "SUPEE-7405 v1.1",
-      "SUPEE-8788",
-      "SUPEE-8788 v2",
-      "Zend Security Upgrade"
-    ],
-    "1.13.1.0": [
-      "SUPEE-1533",
-      "SUPEE-2747",
-      "SUPEE-5344",
-      "SUPEE-5994",
-      "SUPEE-6285",
-      "SUPEE-6482",
-      "SUPEE-6788",
-      "SUPEE-7405",
-      "SUPEE-7405 v1.1",
-      "SUPEE-8788",
-      "SUPEE-8788 v2"
-    ],
-    "1.14.0.0": [
-      "SUPEE-5344",
-      "SUPEE-5994",
-      "SUPEE-6285",
-      "SUPEE-6482",
-      "SUPEE-6788",
-      "SUPEE-7405",
-      "SUPEE-7405 v1.1",
-      "SUPEE-8788",
-      "SUPEE-8788 v2"
-    ],
-    "1.6.x": [
-      "SUPEE-2717",
-      "SUPEE-5994",
-      "SUPEE-6079",
-      "SUPEE-6285",
-      "SUPEE-6482",
-      "SUPEE-6788"
-    ],
-    "1.14.2.1": [
-      "SUPEE-6788",
-      "SUPEE-7405",
-      "SUPEE-7405 v1.1",
-      "SUPEE-8788",
-      "SUPEE-8788 v2"
-    ],
-    "1.12.0.0": [
-      "SUPEE-1533",
-      "SUPEE-2677",
-      "SUPEE-5345",
-      "SUPEE-5994",
-      "SUPEE-6285",
-      "SUPEE-6482",
-      "SUPEE-6788",
-      "SUPEE-7405",
-      "SUPEE-7405 v1.1",
-      "SUPEE-8788",
-      "SUPEE-8788 v2",
-      "Zend Security Upgrade"
-    ],
-    "1.14.2.0": [
-      "SUPEE-5994",
-      "SUPEE-6285",
-      "SUPEE-6482",
-      "SUPEE-6788",
-      "SUPEE-7405",
-      "SUPEE-7405 v1.1",
-      "SUPEE-8788",
-      "SUPEE-8788 v2"
-    ],
-    "1.14.2.4": [
-      "SUPEE-8788",
-      "SUPEE-8788 v2"
-    ],
-    "1.12.0.2": [
-      "SUPEE-1533",
-      "SUPEE-2677",
-      "SUPEE-5345",
-      "SUPEE-5994",
-      "SUPEE-6285",
-      "SUPEE-6482",
-      "SUPEE-6788",
-      "SUPEE-7405",
-      "SUPEE-7405 v1.1",
-      "SUPEE-8788",
-      "SUPEE-8788 v2"
-    ],
-    "1.10.1.1": [
-      "SUPEE-1533",
-      "SUPEE-2677",
-      "SUPEE-5390",
-      "SUPEE-5994",
-      "SUPEE-6285",
-      "SUPEE-6482",
-      "SUPEE-6788",
-      "SUPEE-7405",
-      "SUPEE-7405 v1.1",
-      "SUPEE-8788",
-      "SUPEE-8788 v2",
-      "Zend Security Upgrade"
-    ],
-    "1.8.x": [
-      "SUPEE-2751",
-      "SUPEE-5388",
-      "SUPEE-5994",
-      "SUPEE-6285",
-      "SUPEE-6482",
-      "SUPEE-6788"
-    ],
-    "1.10.0.1": [
-      "SUPEE-1533",
-      "SUPEE-2750",
-      "SUPEE-5388",
-      "SUPEE-5994",
-      "SUPEE-6285",
-      "SUPEE-6482",
-      "SUPEE-6788",
-      "SUPEE-7405",
-      "SUPEE-7405 v1.1",
-      "SUPEE-8788",
-      "SUPEE-8788 v2",
-      "Zend Security Upgrade"
     ]
   }
 }


### PR DESCRIPTION
Updated public patches list for request in hypernode-magerun API call